### PR TITLE
Fix height in display and hide qr on mobile

### DIFF
--- a/src/routes/display/+page.svelte
+++ b/src/routes/display/+page.svelte
@@ -6,7 +6,7 @@
   $: orders = [new Order(123), new Order(456), new Order(789, State.Complete)];
 </script>
 
-  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+  <div class="h-full grid grid-cols-1 gap-4 md:grid-cols-2">
     <div class="flex h-full flex-col border-b-2 border-black p-4 md:border-b-0 md:border-r-2">
       <h2 class="mb-3 text-3xl font-bold md:mb-6 md:text-center md:text-4xl">Straks ferdig...</h2>
       <OrderList {orders} filter={State.Production} />
@@ -19,7 +19,7 @@
     </div>
   </div>
 
-  <div class="absolute bottom-4 left-0 flex">
+  <div class="absolute bottom-4 left-0 hidden md:flex">
     <a href="/">
       <img class="h-24 w-24" src={QR} alt="QR code" />
     </a>


### PR DESCRIPTION
Visningen i /display fyller nå hele høyden av skjermen, og qr-koden er skjult på mobil.

## Før:
![2024-10-19T18:54:05+02:00](https://github.com/user-attachments/assets/cdfd41c7-e504-43f8-b64c-bcca066c9159)
![2024-10-19T18:54:34+02:00](https://github.com/user-attachments/assets/9d63eedf-78bb-4493-9397-5cafda2eeb89)

## Etter:
![2024-10-19T18:58:02+02:00](https://github.com/user-attachments/assets/9633e89d-da74-438d-a3c9-58f05578b8ad)
![2024-10-19T18:54:17+02:00](https://github.com/user-attachments/assets/be6f5c32-633e-426b-87e6-f10cf96a7b1a)
