### PR TITLE
Reuse auth store for /drinks

### DIFF
--- a/src/routes/drinks/+page.svelte
+++ b/src/routes/drinks/+page.svelte
@@ -1,31 +1,14 @@
 <script lang="ts">
-  import PocketBase from "pocketbase";
+  import { pb } from "$lib/stores/authStore";
   import { onMount } from "svelte";
-  // prefixed with PUBLIC_ means that the variables can be read by the frontend. This is very unsafe, and is only temporary for testing !!
-  import {PUBLIC_PB_HOST, PUBLIC_PB_ADMIN_EMAIL, PUBLIC_PB_ADMIN_PASSWORD} from "$env/static/public";
 
-  async function getDrinks() {
-    // Init
-    const pb = new PocketBase(PUBLIC_PB_HOST);
-    await pb.admins.authWithPassword(PUBLIC_PB_ADMIN_EMAIL, PUBLIC_PB_ADMIN_PASSWORD);
+  let drinks: any[] = [];
 
-    const result = await pb.collection("drinks").getFullList({
+  onMount(async () => {
+    drinks = await pb.collection("drinks").getFullList(100, {
       sort: "-created"
     });
-
-    await pb.collection("drinks").subscribe('*', (data) => {
-      console.log(data);
-    })
-
-    console.log(result);
-
-    return result
-  }
-
-  let drinks = []
-  onMount(async () => {
-    drinks = await getDrinks();
-  })
+  });
 </script>
 
 <ul class="list-none">


### PR DESCRIPTION
Det som tok tid var reautentisering via passord under endpointet.

Mitt forslag uansett er kansje å bruke minimalt med tid på denne siden; helst fjerne den. Ettersom funsksjonalitet for å beskrive meny vil fjerne den.

Hvem er enig med å fjerne dette endpointet?