### PR TITLE
Laste drinks på server-side

### DIFF
--- a/src/lib/pocketbase.ts
+++ b/src/lib/pocketbase.ts
@@ -1,0 +1,7 @@
+import PocketBase from "pocketbase";
+import { PUBLIC_PB_HOST } from "$env/static/public";
+
+// Unauthenticated pocketbase instance to be used server-side
+const pb = new PocketBase(PUBLIC_PB_HOST);
+
+export default pb;

--- a/src/routes/drinks/+page.server.ts
+++ b/src/routes/drinks/+page.server.ts
@@ -1,9 +1,7 @@
 import pb from "$lib/pocketbase";
 
-export const load = async () => {
-  return {
+export const load = async () => ({
     drinks: await pb.collection("drinks").getFullList({
       sort: "-created"
     })
-  };
-};
+});

--- a/src/routes/drinks/+page.server.ts
+++ b/src/routes/drinks/+page.server.ts
@@ -1,0 +1,9 @@
+import pb from "$lib/pocketbase";
+
+export const load = async () => {
+  return {
+    drinks: await pb.collection("drinks").getFullList({
+      sort: "-created"
+    })
+  };
+};

--- a/src/routes/drinks/+page.svelte
+++ b/src/routes/drinks/+page.svelte
@@ -1,31 +1,6 @@
 <script lang="ts">
-  import PocketBase from "pocketbase";
-  import { onMount } from "svelte";
-  // prefixed with PUBLIC_ means that the variables can be read by the frontend. This is very unsafe, and is only temporary for testing !!
-  import {PUBLIC_PB_HOST, PUBLIC_PB_ADMIN_EMAIL, PUBLIC_PB_ADMIN_PASSWORD} from "$env/static/public";
-
-  async function getDrinks() {
-    // Init
-    const pb = new PocketBase(PUBLIC_PB_HOST);
-    await pb.admins.authWithPassword(PUBLIC_PB_ADMIN_EMAIL, PUBLIC_PB_ADMIN_PASSWORD);
-
-    const result = await pb.collection("drinks").getFullList({
-      sort: "-created"
-    });
-
-    await pb.collection("drinks").subscribe('*', (data) => {
-      console.log(data);
-    })
-
-    console.log(result);
-
-    return result
-  }
-
-  let drinks = []
-  onMount(async () => {
-    drinks = await getDrinks();
-  })
+  export let data: { drinks };
+  const drinks = data.drinks;
 </script>
 
 <ul class="list-none">


### PR DESCRIPTION
Alternativ løsning på #19

Dette bruker en delt pocketbase-instans som ikke er autentisert, mellom alle requests. Med andre ord: den kan kun lese, og vil dermed aldri møte noen problemer ved at den overskriver eller leser noen andres personlige data.

Den er ment å bruke til å fetche initial data, mens når man subscriber, kan man heller gjøre dette client-side for at koden skal bli enklere.

(`/drinks` er midlertidig og vil fjernes så snart vi faktisk implementerer en meny, men den er bra for å vise hvordan vi bør skrive koden)

Brukt ideer fra #23, men prøvd å skrive koden litt enklere og unngå server-side autentisering.