### PR TITLE
Move fetching client-side

### DIFF
--- a/src/lib/pocketbase.ts
+++ b/src/lib/pocketbase.ts
@@ -1,7 +1,0 @@
-import PocketBase from "pocketbase";
-import { PUBLIC_PB_HOST } from "$env/static/public";
-
-// Unauthenticated pocketbase instance to be used server-side
-const upb = new PocketBase(PUBLIC_PB_HOST);
-
-export default upb;

--- a/src/routes/drinks/+page.server.ts
+++ b/src/routes/drinks/+page.server.ts
@@ -1,7 +1,0 @@
-import upb from "$lib/pocketbase";
-
-export const load = async () => ({
-  drinks: await upb.collection("drinks").getFullList({
-    sort: "-created"
-  })
-});

--- a/src/routes/drinks/+page.ts
+++ b/src/routes/drinks/+page.ts
@@ -1,7 +1,8 @@
 import { pb } from "$lib/stores/authStore";
 
-export const load = async () => ({
+export const load = async ({ fetch }) => ({
   drinks: await pb.collection("drinks").getFullList({
-    sort: "-created"
+    sort: "-created",
+    fetch
   })
 });

--- a/src/routes/drinks/+page.ts
+++ b/src/routes/drinks/+page.ts
@@ -1,0 +1,7 @@
+import { pb } from "$lib/stores/authStore";
+
+export const load = async () => ({
+  drinks: await pb.collection("drinks").getFullList({
+    sort: "-created"
+  })
+});


### PR DESCRIPTION
Fant ut at man kan gjøre det samme som i `+page.server.ts` client-side med `+page.ts`. Dette gjør at vi slipper å ha flere instances av `PocketBase`, og logikken skjer client-side heller enn server-side. Dette bør brukes for initial fetch av all slags data fra pocketbase, da det et betydelig raskere enn å vente på at DOM skal laste i `onMount`.

Gjør i praksis det samme som #28 