### PR TITLE
add default value to Rating name prop

### DIFF
--- a/src/lib/components/Rating.svelte
+++ b/src/lib/components/Rating.svelte
@@ -2,7 +2,7 @@
   export let value: number = 0;
   export let readonly: boolean = false;
   // Name is only required when the component's value can change
-  export let name: string;
+  export let name: string = null;
 
   function inputChange(newValue: number) {
     value = newValue;


### PR DESCRIPTION
Fikser en warning som viste når man ikke ga en `name` til `<Rating />`