### PR TITLE
Add dockerfile and docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ vite.config.ts.timestamp-*
 # Schema
 src/pb.d.ts
 
+# Pocketbase
+/pocketbase-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  pb:
+    build: ./pocketbase
+    ports:
+      - "8080:8080"
+    volumes:
+      - "./pocketbase-data:/pb/pb_data"

--- a/pocketbase/Dockerfile
+++ b/pocketbase/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:latest
+
+ARG PB_VERSION=0.22.21
+
+RUN apk add --no-cache \
+    unzip \
+    ca-certificates \
+    # this is needed only if you want to use scp to copy later your pb_data locally
+    openssh
+
+# download and unzip PocketBase
+ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip /tmp/pb.zip
+RUN unzip /tmp/pb.zip -d /pb/
+
+# uncomment to copy the local pb_migrations dir into the container
+# COPY ./pb_migrations /pb/pb_migrations
+
+# uncomment to copy the local pb_hooks dir into the container
+# COPY ./pb_hooks /pb/pb_hooks
+
+EXPOSE 8080
+
+# start PocketBase
+CMD ["/pb/pocketbase", "serve", "--http=0.0.0.0:8080"]

--- a/readme.md
+++ b/readme.md
@@ -35,16 +35,16 @@ Sider som må til for dette:
 
 ```bash
 PUBLIC_PB_HOST=https://kodekafe-pocketbase.fly.dev
-PB_USER=
-PB_PASS=
-```
-
-Testing av db i svelte:
-
-```bash
-# samme verdier som USER og PASS over
 PUBLIC_PB_ADMIN_EMAIL=
 PUBLIC_PB_ADMIN_PASSWORD=
+```
+
+## Pocketbase
+
+Installer docker for å kjøre pocketbase lokalt.
+
+```bash
+docker compose up
 ```
 
 ## Development


### PR DESCRIPTION
Nå kan man kjøre en lokal instans av pocketbase med `docker compose up`, på `localhost:8080`. For å få en kopi av strukturen, gikk jeg til `Settings > Export collections` på "prod"-pb, og limte det inn i `Settings > Import collections` på testing-db.

Vi kan kanskje også lage en dockerfile for frontenden senere, og kjøre begge deler fra docker compose.